### PR TITLE
build: add docker image for building, update guide

### DIFF
--- a/Dockerfile.kernel
+++ b/Dockerfile.kernel
@@ -1,0 +1,19 @@
+FROM initdc/xuantie-900:22.04-v2.6.1-linux
+
+RUN set -e \
+    # && sed -i 's/archive.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list \
+    && apt-get update
+
+# https://github.com/initdc/cross-make/blob/master/Dockerfile.uboot
+# https://u-boot.readthedocs.io/en/latest/build/gcc.html
+RUN set -e \
+    && apt-get install --no-install-recommends -y \
+    bc bison build-essential \
+    device-tree-compiler dfu-util efitools flex gdisk graphviz imagemagick \
+    liblz4-tool libgnutls28-dev libguestfs-tools libncurses-dev \
+    libpython3-dev libsdl2-dev libssl-dev lz4 lzma lzma-alone openssl \
+    pkg-config python3 python3-asteval python3-coverage python3-filelock \
+    python3-pkg-resources python3-pycryptodome python3-pyelftools \
+    python3-pytest python3-pytest-xdist python3-sphinxcontrib.apidoc \
+    python3-sphinx-rtd-theme python3-subunit python3-testtools \
+    python3-virtualenv swig uuid-dev

--- a/Dockerfile.yocto
+++ b/Dockerfile.yocto
@@ -1,0 +1,51 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    TZ=Asia/Shanghai \
+    LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+RUN set -e \
+    # && sed -i 's/archive.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list \
+    && apt-get update
+
+RUN set -e \
+    && apt-get install --no-install-recommends -y \
+    locales sudo curl ca-certificates
+RUN locale-gen en_US.UTF-8
+
+RUN useradd -c 'ubuntu' -m -d /home/ubuntu -s /bin/bash ubuntu
+RUN set -e \
+    && sed -i -e '/\%sudo/ c \%sudo ALL=(ALL) NOPASSWD: ALL' /etc/sudoers \
+    && usermod -aG sudo ubuntu
+
+RUN set -e \
+    && curl -o /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo \
+    && chmod +x /usr/local/bin/repo
+
+# ref: https://docs.yoctoproject.org/ref-manual/system-requirements.html#ubuntu-and-debian
+
+# RUN set -e \
+#     && apt-get build-dep qemu \
+#     && apt-get remove oss4-dev
+
+RUN set -e \
+    && apt-get install --no-install-recommends -y \
+    # sorting by https://build.moz.one
+    build-essential chrpath cpio debianutils \
+    diffstat gawk gcc git inkscape \
+    iputils-ping libegl1-mesa liblz4-tool \
+    libsdl1.2-dev make mesa-common-dev \
+    pylint3 python3 python3-git \
+    python3-jinja2 python3-pexpect \
+    python3-pip python3-subunit socat \
+    texinfo texlive-latex-extra unzip wget \
+    xterm xz-utils zstd \
+    && apt-get autoremove --purge \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install sphinx sphinx_rtd_theme pyyaml
+
+USER ubuntu
+WORKDIR /home/ubuntu/
+
+ENTRYPOINT [ "/bin/bash" ]

--- a/README_en.md
+++ b/README_en.md
@@ -1,3 +1,77 @@
-# LicheePi4A
-LicheePi4A info&amp;sdk
+# LicheePi 4A
 
+> Building guide & SDK for LicheePi 4A
+
+## Prepare
+
+- Docker
+
+  ```sh
+  docker buildx build -t thead-yocto:v1 -f Dockerfile.yocto .
+
+  docker buildx build -t thead-kernel:v1 -f Dockerfile.kernel .
+  ```
+
+- git
+
+  ```sh
+  git submodule update --init --recursive --depth 1
+  ```
+
+- repo (fetch)
+
+  ```sh
+  mkdir riscv-yocto && cd riscv-yocto
+  repo init -u https://github.com/riscv/meta-riscv -b master -m tools/manifests/riscv-yocto.xml
+  repo sync
+  repo start work --all
+  ```
+
+## Run
+
+- kernel u-boot opensbi driver etc.
+
+  ```sh
+  docker run --name runner-kernel -it -v $PWD/external/revyos:/root/workdir thead-kernel:v1
+  
+  # in docker
+  export PATH="$PATH:/root/Xuantie-900-gcc-linux-5.10.4-glibc-x86_64-V2.6.1/bin"
+  cd ~/workdir
+
+  # make-env tool
+  apt update && apt install ruby
+  gem install make-env
+  eval $(make-env riscv auto)
+  ```
+
+- yocto
+
+  > Machine/Target支持列表
+
+  https://gitee.com/thead-yocto/documents#machinetarget%E6%94%AF%E6%8C%81%E5%88%97%E8%A1%A8
+
+  ```sh
+  docker run --name runner-yocto -it -v $PWD/external/thead-yocto:/home/ubuntu/workdir thead-yocto:v1
+
+  # in docker
+  sudo apt-get update && sudo apt-get -y install file python bison flex
+  sudo chown -R ubuntu:ubuntu workdir/
+  cd workdir/xuantie-yocto
+  source openembedded-core/oe-init-build-env thead-build/light-fm
+
+  MACHINE=light-lpi4a bitbake thead-image-linux
+  ```
+
+- run after exit
+
+  ```sh
+  docker container start runner-kernel
+  docker exec -it runner-kernel /bin/bash
+  ```
+
+## Related repos
+
+- https://github.com/initdc/cross-make
+- https://github.com/initdc/xuantie-900-gcc
+- https://github.com/initdc/yocto-rockchip
+- https://github.com/initdc/make-env


### PR DESCRIPTION
With published docker image, we don't prepare building env every time.

https://hub.docker.com/r/initdc/thead-kernel/tags
https://hub.docker.com/r/initdc/thead-yocto/tags

run cmd will be
```
docker run --name runner-kernel -it -v $PWD/external/revyos:/root/workdir initdc/thead-kernel
docker run --name runner-yocto -it -v $PWD/external/thead-yocto:/home/ubuntu/workdir initdc/thead-yocto
```